### PR TITLE
ci: bump parent to 17.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>15</version>
+        <version>17.2</version>
     </parent>
 
     <properties>


### PR DESCRIPTION

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.8.0-upgrade-project-config`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-xml-json/1.8.0-upgrade-project-config/gravitee-policy-xml-json-1.8.0-upgrade-project-config.zip)
  <!-- Version placeholder end -->
