### PR TITLE
fix: fallback to default charset when specified one  is invalid

### DIFF
--- a/src/main/java/io/gravitee/policy/xml2json/utils/CharsetHelper.java
+++ b/src/main/java/io/gravitee/policy/xml2json/utils/CharsetHelper.java
@@ -49,6 +49,10 @@ public class CharsetHelper {
         String charsetName = mediaType.substring(mediaType.lastIndexOf('=') + 1);
         charsetName = charsetName.replace("\"", "");
 
-        return Charset.isSupported(charsetName) ? Charset.forName(charsetName) : Charset.defaultCharset();
+        try {
+            return Charset.isSupported(charsetName) ? Charset.forName(charsetName) : Charset.defaultCharset();
+        } catch (Exception e) {
+            return Charset.defaultCharset();
+        }
     }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-1146

**Description**

If the request or response contains a `Content-Type` header including a charset, the policy tries to apply the given charset. When this charset is invalid, an exception may be thrown and the call fails.

For example, calling an API with an XML to JSON policy like this

```
curl -XPOST -H "Content-Type: application/xml;charset=UTF-8;" https://localhost:8082/xml2json -d "<a>b</a>"
```

fails due to an invalid char ';' with the following error in the logs:

```
18:57:18.255 [vert.x-eventloop-thread-2] [] ERROR i.g.g.policy.impl.OrderedPolicyChain - Unexpected error while running onXXXXContent for policy io.gravitee.gateway.policy.impl.ExecutablePolicy@153e6827
io.gravitee.gateway.policy.PolicyException: java.nio.charset.IllegalCharsetNameException: UTF-8,
	at io.gravitee.gateway.policy.impl.ExecutablePolicy.stream(ExecutablePolicy.java:124)
	at io.gravitee.gateway.policy.impl.StreamablePolicyChain.prepareStreamablePolicyChain(StreamablePolicyChain.java:62)
	at io.gravitee.gateway.policy.impl.StreamablePolicyChain.doNext(StreamablePolicyChain.java:49)
	at io.gravitee.gateway.policy.impl.PolicyChain.handle(PolicyChain.java:96)
	at io.gravitee.gateway.policy.impl.PolicyChain.handle(PolicyChain.java:38)
	at io.gravitee.gateway.core.processor.chain.AbstractStreamableProcessorChain.handle(AbstractStreamableProcessorChain.java:62)
	at ......
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.nio.charset.IllegalCharsetNameException: UTF-8,
	at java.base/java.nio.charset.Charset.checkName(Charset.java:305)
	at java.base/java.nio.charset.Charset.lookup2(Charset.java:481)
	at java.base/java.nio.charset.Charset.lookup(Charset.java:461)
	at java.base/java.nio.charset.Charset.isSupported(Charset.java:502)
	at io.gravitee.policy.xml2json.utils.CharsetHelper.extractFromContentType(CharsetHelper.java:52)
	at io.gravitee.policy.xml2json.utils.CharsetHelper.extractCharset(CharsetHelper.java:35)
	at io.gravitee.policy.xml2json.XmlToJsonTransformationPolicy.onRequestContent(XmlToJsonTransformationPolicy.java:76)
	at io.gravitee.gateway.policy.impl.ExecutablePolicy.stream(ExecutablePolicy.java:120)
	... 95 common frames omitted
```

This fix allows ignoring invalid charsets and silently fallback to the default charset.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.8.2-apim-1146-fallback-default-charset-when-invalid-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-xml-json/1.8.2-apim-1146-fallback-default-charset-when-invalid-SNAPSHOT/gravitee-policy-xml-json-1.8.2-apim-1146-fallback-default-charset-when-invalid-SNAPSHOT.zip)
  <!-- Version placeholder end -->
