### PR TITLE
feat: migrate policy to support messages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@2.0
+    gravitee: gravitee-io/gravitee@4.0.0
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)
@@ -22,7 +22,7 @@ workflows:
     setup_release:
         when:
             matches:
-                pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+                pattern: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
                 value: << pipeline.git.tag >>
         jobs:
             - gravitee/setup_plugin-release-config:
@@ -32,4 +32,4 @@ workflows:
                               - /.*/
                       tags:
                           only:
-                              - /^[0-9]+\.[0-9]+\.[0-9]+$/
+                              - /^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$/

--- a/README.adoc
+++ b/README.adoc
@@ -7,6 +7,15 @@ image:https://img.shields.io/badge/semantic--release-conventional%20commits-e100
 image:https://circleci.com/gh/gravitee-io/gravitee-policy-xml-json.svg?style=svg["CircleCI", link="https://circleci.com/gh/gravitee-io/gravitee-policy-xml-json"]
 endif::[]
 
+== Compatibility matrix
+
+|===
+|Plugin version | APIM version
+
+|1.x                 | 3.x or lower
+|2.x and upper       | 4.x or higher
+|===
+
 == Phase
 
 [cols="2*", options="header"]
@@ -61,4 +70,4 @@ You can configure the policy with the following options:
 
 === Nested objects
 
-To limit the processing time in case of nested object, a default max depth of nested object has been defined to 1000. This default value can be overridden using the environment variable `gravitee_policy_xmljson_maxdepth`.
+To limit the processing time and memory consumption in case of nested object, a default max depth of nested object has been defined to 100. This default value can be overridden using the environment variable `gravitee_policy_xmljson_maxdepth`.

--- a/pom.xml
+++ b/pom.xml
@@ -13,17 +13,20 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>21.0.0</version>
+        <version>21.0.1</version>
     </parent>
 
     <properties>
-        <gravitee-gateway-buffer.version>3.18.0</gravitee-gateway-buffer.version>
-        <gravitee-bom.version>4.0.0</gravitee-bom.version>
-        <gravitee-node.version>1.24.8</gravitee-node.version>
-        <gravitee-gateway-api.version>1.34.2</gravitee-gateway-api.version>
+        <gravitee-apim.version>4.0.0-SNAPSHOT</gravitee-apim.version>
+        <gravitee-bom.version>5.0.0</gravitee-bom.version>
+        <gravitee-node.version>3.1.0-alpha.11</gravitee-node.version>
+        <gravitee-gateway-api.version>3.0.0-alpha.6</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-common.version>1.27.0</gravitee-common.version>
-        <gravitee-expression-language.version>1.9.7</gravitee-expression-language.version>
+        <gravitee-common.version>2.1.1</gravitee-common.version>
+        <gravitee-expression-language.version>2.2.1</gravitee-expression-language.version>
+        <gravitee-entrypoint-http-post.version>1.0.0-alpha.1</gravitee-entrypoint-http-post.version>
+        <gravitee-entrypoint-http-get.version>1.0.0-alpha.4</gravitee-entrypoint-http-get.version>
+        <gravitee-reactor-message.version>1.0.0-alpha.8</gravitee-reactor-message.version>
 
         <swagger-parser.version>2.0.14</swagger-parser.version>
         <slf4j.version>1.7.26</slf4j.version>
@@ -105,7 +108,14 @@
         <dependency>
             <groupId>io.gravitee.apim.gateway</groupId>
             <artifactId>gravitee-apim-gateway-buffer</artifactId>
-            <version>${gravitee-gateway-buffer.version}</version>
+            <version>${gravitee-apim.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.apim.gateway</groupId>
+            <artifactId>gravitee-apim-gateway-tests-sdk</artifactId>
+            <version>${gravitee-apim.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -142,6 +152,42 @@
             <groupId>io.gravitee.el</groupId>
             <artifactId>gravitee-expression-language</artifactId>
             <version>${gravitee-expression-language.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.apim.plugin.entrypoint</groupId>
+            <artifactId>gravitee-apim-plugin-entrypoint-http-proxy</artifactId>
+            <version>${gravitee-apim.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.graviteesource.entrypoint</groupId>
+            <artifactId>gravitee-entrypoint-http-get</artifactId>
+            <version>${gravitee-entrypoint-http-get.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.graviteesource.entrypoint</groupId>
+            <artifactId>gravitee-entrypoint-http-post</artifactId>
+            <version>${gravitee-entrypoint-http-post.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.apim.plugin.endpoint</groupId>
+            <artifactId>gravitee-apim-plugin-endpoint-http-proxy</artifactId>
+            <version>${gravitee-apim.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.apim.plugin.endpoint</groupId>
+            <artifactId>gravitee-apim-plugin-endpoint-mock</artifactId>
+            <version>${gravitee-apim.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.graviteesource.reactor</groupId>
+            <artifactId>gravitee-reactor-message</artifactId>
+            <version>${gravitee-reactor-message.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/graviteesource/policy/v3/xml2json/XmlToJsonTransformationPolicyV3.java
+++ b/src/main/java/com/graviteesource/policy/v3/xml2json/XmlToJsonTransformationPolicyV3.java
@@ -1,0 +1,100 @@
+package com.graviteesource.policy.v3.xml2json;
+
+import com.graviteesource.policy.xml2json.configuration.PolicyScope;
+import com.graviteesource.policy.xml2json.configuration.XmlToJsonTransformationPolicyConfiguration;
+import com.graviteesource.policy.xml2json.deployer.XmlToJsonTransformationPolicyDeploymentLifecycle;
+import com.graviteesource.policy.xml2json.transformer.XML;
+import com.graviteesource.policy.xml2json.utils.CharsetHelper;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.gateway.api.ExecutionContext;
+import io.gravitee.gateway.api.Request;
+import io.gravitee.gateway.api.Response;
+import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.api.http.stream.TransformableRequestStreamBuilder;
+import io.gravitee.gateway.api.http.stream.TransformableResponseStreamBuilder;
+import io.gravitee.gateway.api.stream.ReadWriteStream;
+import io.gravitee.gateway.api.stream.exception.TransformationException;
+import io.gravitee.node.api.configuration.Configuration;
+import io.gravitee.plugin.api.annotations.Plugin;
+import io.gravitee.policy.api.PolicyChain;
+import io.gravitee.policy.api.annotations.OnRequestContent;
+import io.gravitee.policy.api.annotations.OnResponseContent;
+import java.nio.charset.Charset;
+import java.util.function.Function;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Plugin(deployment = XmlToJsonTransformationPolicyDeploymentLifecycle.class)
+public class XmlToJsonTransformationPolicyV3 {
+
+    public static final String POLICY_XML_JSON_MAXDEPTH = "policy.xml-json.maxdepth";
+    public static final int DEFAULT_MAX_DEPH = 100;
+    public static final String UTF8_CHARSET_NAME = "UTF-8";
+    public static final String APPLICATION_JSON = MediaType.APPLICATION_JSON + ";charset=" + UTF8_CHARSET_NAME;
+
+    private Integer maxDepth;
+
+    /**
+     * XML to Json transformation configuration
+     */
+    protected final XmlToJsonTransformationPolicyConfiguration xmlToJsonTransformationPolicyConfiguration;
+
+    public XmlToJsonTransformationPolicyV3(final XmlToJsonTransformationPolicyConfiguration xmlToJsonTransformationPolicyConfiguration) {
+        this.xmlToJsonTransformationPolicyConfiguration = xmlToJsonTransformationPolicyConfiguration;
+    }
+
+    @OnResponseContent
+    public ReadWriteStream onResponseContent(Response response, PolicyChain chain, ExecutionContext context) {
+        if (
+            xmlToJsonTransformationPolicyConfiguration.getScope() == null ||
+            xmlToJsonTransformationPolicyConfiguration.getScope() == PolicyScope.RESPONSE
+        ) {
+            Charset charset = CharsetHelper.extractCharset(response.headers());
+
+            return TransformableResponseStreamBuilder
+                .on(response)
+                .chain(chain)
+                .contentType(APPLICATION_JSON)
+                .transform(map(charset, getMaxDepth(context)))
+                .build();
+        }
+
+        return null;
+    }
+
+    @OnRequestContent
+    public ReadWriteStream onRequestContent(Request request, PolicyChain chain, ExecutionContext context) {
+        if (xmlToJsonTransformationPolicyConfiguration.getScope() == PolicyScope.REQUEST) {
+            Charset charset = CharsetHelper.extractCharset(request.headers());
+            return TransformableRequestStreamBuilder
+                .on(request)
+                .chain(chain)
+                .contentType(APPLICATION_JSON)
+                .transform(map(charset, getMaxDepth(context)))
+                .build();
+        }
+
+        return null;
+    }
+
+    private Function<Buffer, Buffer> map(Charset charset, int depth) {
+        return input -> {
+            try {
+                String encodedPayload = new String(input.toString(charset).getBytes(UTF8_CHARSET_NAME));
+                return Buffer.buffer(XML.toJSONObject(encodedPayload, depth).toString(), UTF8_CHARSET_NAME);
+            } catch (Exception ex) {
+                throw new TransformationException("Unable to transform XML into JSON: " + ex.getMessage(), ex);
+            }
+        };
+    }
+
+    private int getMaxDepth(ExecutionContext context) {
+        if (this.maxDepth == null) {
+            this.maxDepth =
+                context.getComponent(Configuration.class).getProperty(POLICY_XML_JSON_MAXDEPTH, Integer.class, DEFAULT_MAX_DEPH);
+        }
+        return maxDepth;
+    }
+}

--- a/src/main/java/com/graviteesource/policy/xml2json/XmlToJsonTransformationPolicy.java
+++ b/src/main/java/com/graviteesource/policy/xml2json/XmlToJsonTransformationPolicy.java
@@ -1,100 +1,124 @@
 package com.graviteesource.policy.xml2json;
 
-import com.graviteesource.policy.xml2json.configuration.PolicyScope;
+import com.graviteesource.policy.v3.xml2json.XmlToJsonTransformationPolicyV3;
 import com.graviteesource.policy.xml2json.configuration.XmlToJsonTransformationPolicyConfiguration;
 import com.graviteesource.policy.xml2json.deployer.XmlToJsonTransformationPolicyDeploymentLifecycle;
 import com.graviteesource.policy.xml2json.transformer.XML;
 import com.graviteesource.policy.xml2json.utils.CharsetHelper;
-import io.gravitee.common.http.MediaType;
-import io.gravitee.gateway.api.ExecutionContext;
-import io.gravitee.gateway.api.Request;
-import io.gravitee.gateway.api.Response;
+import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.gateway.api.buffer.Buffer;
-import io.gravitee.gateway.api.http.stream.TransformableRequestStreamBuilder;
-import io.gravitee.gateway.api.http.stream.TransformableResponseStreamBuilder;
-import io.gravitee.gateway.api.stream.ReadWriteStream;
+import io.gravitee.gateway.api.http.HttpHeaderNames;
+import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.api.stream.exception.TransformationException;
+import io.gravitee.gateway.reactive.api.ExecutionFailure;
+import io.gravitee.gateway.reactive.api.context.GenericExecutionContext;
+import io.gravitee.gateway.reactive.api.context.HttpExecutionContext;
+import io.gravitee.gateway.reactive.api.context.MessageExecutionContext;
+import io.gravitee.gateway.reactive.api.message.Message;
+import io.gravitee.gateway.reactive.api.policy.Policy;
 import io.gravitee.node.api.configuration.Configuration;
 import io.gravitee.plugin.api.annotations.Plugin;
-import io.gravitee.policy.api.PolicyChain;
-import io.gravitee.policy.api.annotations.OnRequestContent;
-import io.gravitee.policy.api.annotations.OnResponseContent;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Maybe;
 import java.nio.charset.Charset;
-import java.util.function.Function;
+import java.nio.charset.StandardCharsets;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
 @Plugin(deployment = XmlToJsonTransformationPolicyDeploymentLifecycle.class)
-public class XmlToJsonTransformationPolicy {
+public class XmlToJsonTransformationPolicy extends XmlToJsonTransformationPolicyV3 implements Policy {
 
-    public static final String POLICY_XML_JSON_MAXDEPTH = "policy.xml-json.maxdepth";
-    public static final int DEFAULT_MAX_DEPH = 1000;
-    private static final String UTF8_CHARSET_NAME = "UTF-8";
-    static final String APPLICATION_JSON = MediaType.APPLICATION_JSON + ";charset=" + UTF8_CHARSET_NAME;
+    private static final String INVALID_PAYLOAD_FAILURE_KEY = "XML_INVALID_PAYLOAD";
+    private static final String INVALID_MESSAGE_PAYLOAD_FAILURE_KEY = "XML_INVALID_MESSAGE_PAYLOAD";
 
     private Integer maxDepth;
 
-    /**
-     * XML to Json transformation configuration
-     */
-    private final XmlToJsonTransformationPolicyConfiguration xmlToJsonTransformationPolicyConfiguration;
-
-    public XmlToJsonTransformationPolicy(final XmlToJsonTransformationPolicyConfiguration xmlToJsonTransformationPolicyConfiguration) {
-        this.xmlToJsonTransformationPolicyConfiguration = xmlToJsonTransformationPolicyConfiguration;
+    public XmlToJsonTransformationPolicy(final XmlToJsonTransformationPolicyConfiguration configuration) {
+        super(configuration);
     }
 
-    @OnResponseContent
-    public ReadWriteStream onResponseContent(Response response, PolicyChain chain, ExecutionContext context) {
-        if (
-            xmlToJsonTransformationPolicyConfiguration.getScope() == null ||
-            xmlToJsonTransformationPolicyConfiguration.getScope() == PolicyScope.RESPONSE
-        ) {
-            Charset charset = CharsetHelper.extractCharset(response.headers());
-
-            return TransformableResponseStreamBuilder
-                .on(response)
-                .chain(chain)
-                .contentType(APPLICATION_JSON)
-                .transform(map(charset, getMaxDepth(context)))
-                .build();
-        }
-
-        return null;
+    private static void setContentHeaders(final HttpHeaders headers, final Buffer jsonBuffer) {
+        headers.set(HttpHeaderNames.CONTENT_TYPE, APPLICATION_JSON);
+        headers.set(HttpHeaderNames.CONTENT_LENGTH, Integer.toString(jsonBuffer.length()));
     }
 
-    @OnRequestContent
-    public ReadWriteStream onRequestContent(Request request, PolicyChain chain, ExecutionContext context) {
-        if (xmlToJsonTransformationPolicyConfiguration.getScope() == PolicyScope.REQUEST) {
-            Charset charset = CharsetHelper.extractCharset(request.headers());
-            return TransformableRequestStreamBuilder
-                .on(request)
-                .chain(chain)
-                .contentType(APPLICATION_JSON)
-                .transform(map(charset, getMaxDepth(context)))
-                .build();
-        }
-
-        return null;
+    @Override
+    public String id() {
+        return "xml-json";
     }
 
-    private Function<Buffer, Buffer> map(Charset charset, int depth) {
-        return input -> {
-            try {
-                String encodedPayload = new String(input.toString(charset).getBytes(UTF8_CHARSET_NAME));
-                return Buffer.buffer(XML.toJSONObject(encodedPayload, depth).toString(), UTF8_CHARSET_NAME);
-            } catch (Exception ex) {
-                throw new TransformationException("Unable to transform XML into JSON: " + ex.getMessage(), ex);
-            }
-        };
+    @Override
+    public Completable onRequest(HttpExecutionContext ctx) {
+        return ctx.request().onBody(body -> transformBodyToJson(ctx, body, ctx.request().headers(), HttpStatusCode.BAD_REQUEST_400));
     }
 
-    private int getMaxDepth(ExecutionContext context) {
+    @Override
+    public Completable onResponse(HttpExecutionContext ctx) {
+        return ctx
+            .response()
+            .onBody(body -> transformBodyToJson(ctx, body, ctx.response().headers(), HttpStatusCode.INTERNAL_SERVER_ERROR_500));
+    }
+
+    private Maybe<Buffer> transformBodyToJson(
+        HttpExecutionContext ctx,
+        Maybe<Buffer> bodyUpstream,
+        HttpHeaders headers,
+        int failureHttpCode
+    ) {
+        return bodyUpstream
+            .flatMap(buffer -> transformToJson(buffer, CharsetHelper.extractCharset(headers), getMaxDepth(ctx)))
+            .doOnSuccess(jsonBuffer -> setContentHeaders(headers, jsonBuffer))
+            .onErrorResumeWith(
+                ctx.interruptBodyWith(
+                    new ExecutionFailure(failureHttpCode)
+                        .key(INVALID_PAYLOAD_FAILURE_KEY)
+                        .message("Unable to transform invalid XML to Json")
+                )
+            );
+    }
+
+    @Override
+    public Completable onMessageRequest(MessageExecutionContext ctx) {
+        return ctx
+            .request()
+            .onMessage(message -> transformMessageToJson(ctx, message, ctx.request().headers(), HttpStatusCode.BAD_REQUEST_400));
+    }
+
+    @Override
+    public Completable onMessageResponse(MessageExecutionContext ctx) {
+        return ctx
+            .response()
+            .onMessage(message -> transformMessageToJson(ctx, message, ctx.response().headers(), HttpStatusCode.INTERNAL_SERVER_ERROR_500));
+    }
+
+    private Maybe<Message> transformMessageToJson(MessageExecutionContext ctx, Message message, HttpHeaders headers, int failureHttpCode) {
+        return transformToJson(message.content(), CharsetHelper.extractCharset(headers), getMaxDepth(ctx))
+            .map(message::content)
+            .doOnSuccess(jsonMessage -> setContentHeaders(message.headers(), jsonMessage.content()))
+            .onErrorResumeWith(
+                ctx.interruptMessageWith(
+                    new ExecutionFailure(failureHttpCode)
+                        .key(INVALID_MESSAGE_PAYLOAD_FAILURE_KEY)
+                        .message("Unable to transform invalid XML message to JSON")
+                )
+            );
+    }
+
+    private int getMaxDepth(GenericExecutionContext ctx) {
         if (this.maxDepth == null) {
-            this.maxDepth =
-                context.getComponent(Configuration.class).getProperty(POLICY_XML_JSON_MAXDEPTH, Integer.class, DEFAULT_MAX_DEPH);
+            this.maxDepth = ctx.getComponent(Configuration.class).getProperty(POLICY_XML_JSON_MAXDEPTH, Integer.class, DEFAULT_MAX_DEPH);
         }
-        return maxDepth;
+        return this.maxDepth;
+    }
+
+    private Maybe<Buffer> transformToJson(Buffer buffer, Charset charset, int depth) {
+        try {
+            String encodedPayload = new String(buffer.toString(charset).getBytes(StandardCharsets.UTF_8));
+            return Maybe.just(Buffer.buffer(XML.toJSONObject(encodedPayload, depth).toString(), UTF8_CHARSET_NAME));
+        } catch (Exception e) {
+            return Maybe.error(new TransformationException("Unable to transform XML into JSON:" + e.getMessage(), e));
+        }
     }
 }

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -6,3 +6,5 @@ class=com.graviteesource.policy.xml2json.XmlToJsonTransformationPolicy
 type=policy
 category=transformation
 icon=xml-to-json.svg
+proxy=REQUEST,RESPONSE
+message=REQUEST,RESPONSE,MESSAGE_REQUEST,MESSAGE_RESPONSE

--- a/src/test/java/com/graviteesource/policy/v3/xml2json/XmlToJsonTransformationPolicyV3IntegrationTest.java
+++ b/src/test/java/com/graviteesource/policy/v3/xml2json/XmlToJsonTransformationPolicyV3IntegrationTest.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.graviteesource.policy.v3.xml2json;
+
+import com.graviteesource.policy.xml2json.XmlToJsonTransformationPolicyV3CompatibilityIntegrationTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayMode;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@GatewayTest(mode = GatewayMode.V3)
+public class XmlToJsonTransformationPolicyV3IntegrationTest extends XmlToJsonTransformationPolicyV3CompatibilityIntegrationTest {}

--- a/src/test/java/com/graviteesource/policy/v3/xml2json/XmlToJsonTransformationPolicyV3Test.java
+++ b/src/test/java/com/graviteesource/policy/v3/xml2json/XmlToJsonTransformationPolicyV3Test.java
@@ -1,0 +1,274 @@
+package com.graviteesource.policy.v3.xml2json;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.graviteesource.policy.xml2json.XmlToJsonTransformationPolicy;
+import com.graviteesource.policy.xml2json.configuration.PolicyScope;
+import com.graviteesource.policy.xml2json.configuration.XmlToJsonTransformationPolicyConfiguration;
+import io.gravitee.gateway.api.ExecutionContext;
+import io.gravitee.gateway.api.Request;
+import io.gravitee.gateway.api.Response;
+import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.api.http.HttpHeaderNames;
+import io.gravitee.gateway.api.http.HttpHeaders;
+import io.gravitee.gateway.api.stream.ReadWriteStream;
+import io.gravitee.node.api.configuration.Configuration;
+import io.gravitee.policy.api.PolicyChain;
+import io.gravitee.reporter.api.http.Metrics;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringWriter;
+import java.time.Instant;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+class XmlToJsonTransformationPolicyV3Test {
+
+    private XmlToJsonTransformationPolicyV3 cut;
+
+    @Mock
+    private XmlToJsonTransformationPolicyConfiguration configuration;
+
+    @Mock
+    private PolicyChain policyChain;
+
+    @Spy
+    private Request request;
+
+    @Spy
+    private Response response;
+
+    @Mock
+    private ExecutionContext executionContext;
+
+    @BeforeEach
+    public void setUp() {
+        cut = new XmlToJsonTransformationPolicyV3(configuration);
+        final Configuration config = mock(Configuration.class);
+        when(
+            config.getProperty(
+                XmlToJsonTransformationPolicy.POLICY_XML_JSON_MAXDEPTH,
+                Integer.class,
+                XmlToJsonTransformationPolicy.DEFAULT_MAX_DEPH
+            )
+        )
+            .thenReturn(XmlToJsonTransformationPolicy.DEFAULT_MAX_DEPH);
+        when(executionContext.getComponent(Configuration.class)).thenReturn(config);
+    }
+
+    @Test
+    @DisplayName("Should transform and add header OnRequestContent")
+    void shouldTransformAndAddHeadersOnRequestContent() throws Exception {
+        String input = loadResource("/com/graviteesource/policy/xml2json/input.xml");
+        String expected = loadResource("/com/graviteesource/policy/xml2json/expected.json");
+
+        // Prepare context
+        when(configuration.getScope()).thenReturn(PolicyScope.REQUEST);
+        when(request.headers()).thenReturn(HttpHeaders.create());
+
+        final ReadWriteStream result = cut.onRequestContent(request, policyChain, executionContext);
+        assertThat(result).isNotNull();
+        result.bodyHandler(resultBody -> {
+            assertResultingJsonObjectsAreEquals(expected, resultBody);
+        });
+
+        result.write(Buffer.buffer(input));
+        result.end();
+
+        assertThat(request.headers().names()).contains(HttpHeaderNames.CONTENT_TYPE);
+        assertThat(request.headers().getAll(HttpHeaderNames.CONTENT_TYPE).get(0)).isEqualTo(XmlToJsonTransformationPolicy.APPLICATION_JSON);
+        assertThat(request.headers().names()).doesNotContain(HttpHeaderNames.TRANSFER_ENCODING);
+        assertThat(request.headers().names()).contains(HttpHeaderNames.CONTENT_LENGTH);
+    }
+
+    @Test
+    @DisplayName("Should not transform when TransformationException thrown OnRequestContent")
+    void shouldNotTransformAndAddHeadersOnRequestContent() throws Exception {
+        String input = loadResource("/com/graviteesource/policy/xml2json/invalid-input.xml");
+
+        // Prepare context
+        when(configuration.getScope()).thenReturn(PolicyScope.REQUEST);
+        when(request.headers()).thenReturn(HttpHeaders.create());
+        when(request.metrics()).thenReturn(Metrics.on(Instant.now().toEpochMilli()).build());
+
+        final ReadWriteStream result = cut.onRequestContent(request, policyChain, executionContext);
+        assertThat(result).isNotNull();
+
+        result.write(Buffer.buffer(input));
+        result.end();
+
+        assertThat(request.headers().names()).doesNotContain(HttpHeaderNames.CONTENT_TYPE);
+        assertThat(request.headers().names()).doesNotContain(HttpHeaderNames.TRANSFER_ENCODING);
+        assertThat(request.headers().names()).doesNotContain(HttpHeaderNames.CONTENT_LENGTH);
+        assertThat(request.metrics().getMessage()).contains("Unable to transform XML into JSON:");
+        verify(policyChain, times(1)).streamFailWith(any());
+    }
+
+    @Test
+    @DisplayName("Should reject too deep nested objects")
+    void shouldRejectTooDeepNestedObject() throws Exception {
+        String input = loadResource("/com/graviteesource/policy/xml2json/invalid-nested-object.xml");
+
+        // Prepare context
+        when(configuration.getScope()).thenReturn(PolicyScope.REQUEST);
+        when(request.headers()).thenReturn(HttpHeaders.create());
+        when(request.metrics()).thenReturn(Metrics.on(Instant.now().toEpochMilli()).build());
+
+        final ReadWriteStream result = cut.onRequestContent(request, policyChain, executionContext);
+        assertThat(result).isNotNull();
+
+        result.write(Buffer.buffer(input));
+        result.end();
+
+        assertThat(request.headers().names()).doesNotContain(HttpHeaderNames.CONTENT_TYPE);
+        assertThat(request.headers().names()).doesNotContain(HttpHeaderNames.TRANSFER_ENCODING);
+        assertThat(request.headers().names()).doesNotContain(HttpHeaderNames.CONTENT_LENGTH);
+        assertThat(request.metrics().getMessage()).contains("Unable to transform XML into JSON:");
+        verify(policyChain, times(1)).streamFailWith(any());
+    }
+
+    @Test
+    @DisplayName("Should transform and add header OnResponseContent")
+    void shouldTransformAndAddHeadersOnResponseContent() throws Exception {
+        String input = loadResource("/com/graviteesource/policy/xml2json/input.xml");
+        String expected = loadResource("/com/graviteesource/policy/xml2json/expected.json");
+
+        // Prepare context
+        when(configuration.getScope()).thenReturn(PolicyScope.RESPONSE);
+        when(response.headers()).thenReturn(HttpHeaders.create());
+
+        final ReadWriteStream result = cut.onResponseContent(response, policyChain, executionContext);
+        assertThat(result).isNotNull();
+        result.bodyHandler(resultBody -> {
+            assertResultingJsonObjectsAreEquals(expected, resultBody);
+        });
+
+        result.write(Buffer.buffer(input));
+        result.end();
+
+        assertThat(response.headers().names()).contains(HttpHeaderNames.CONTENT_TYPE);
+        assertThat(response.headers().getAll(HttpHeaderNames.CONTENT_TYPE).get(0))
+            .isEqualTo(XmlToJsonTransformationPolicy.APPLICATION_JSON);
+        assertThat(response.headers().names()).doesNotContain(HttpHeaderNames.TRANSFER_ENCODING);
+        assertThat(response.headers().names()).contains(HttpHeaderNames.CONTENT_LENGTH);
+    }
+
+    @Test
+    @DisplayName("Should not transform when TransformationException thrown OnResponseContent")
+    void shouldNotTransformAndAddHeadersOnResponseContent() throws Exception {
+        String input = loadResource("/com/graviteesource/policy/xml2json/invalid-input.xml");
+
+        // Prepare context
+        when(configuration.getScope()).thenReturn(PolicyScope.RESPONSE);
+        when(response.headers()).thenReturn(HttpHeaders.create());
+
+        final ReadWriteStream result = cut.onResponseContent(response, policyChain, executionContext);
+        assertThat(result).isNotNull();
+
+        result.write(Buffer.buffer(input));
+        result.end();
+
+        assertThat(response.headers().names()).doesNotContain(HttpHeaderNames.CONTENT_TYPE);
+        assertThat(response.headers().names()).doesNotContain(HttpHeaderNames.TRANSFER_ENCODING);
+        assertThat(response.headers().names()).doesNotContain(HttpHeaderNames.CONTENT_LENGTH);
+        verify(policyChain, times(1)).streamFailWith(any());
+    }
+
+    @ParameterizedTest
+    @DisplayName("Should not fail when invalid charset is specified on request content")
+    @ValueSource(
+        strings = {
+            "wrong",
+            "application/soap+xml; charset=utf-8;",
+            "  ",
+            "application/soap+xml; charset=utf-8,",
+            "application/soap+xml; charset=utf-8",
+        }
+    )
+    void shouldNotFailWhenInvalidCharsetIsSpecifiedOnRequestContent(String contentType) throws Exception {
+        String input = loadResource("/com/graviteesource/policy/xml2json/input.xml");
+        String expected = loadResource("/com/graviteesource/policy/xml2json/expected.json");
+
+        // Prepare context
+        final HttpHeaders headers = HttpHeaders.create();
+        headers.set(HttpHeaderNames.CONTENT_TYPE, contentType);
+        when(configuration.getScope()).thenReturn(PolicyScope.REQUEST);
+        when(request.headers()).thenReturn(headers);
+
+        final ReadWriteStream result = cut.onRequestContent(request, policyChain, executionContext);
+        assertThat(result).isNotNull();
+        result.bodyHandler(resultBody -> assertResultingJsonObjectsAreEquals(expected, resultBody));
+
+        result.write(Buffer.buffer(input));
+        result.end();
+
+        assertThat(request.headers().names()).contains(HttpHeaderNames.CONTENT_TYPE);
+        assertThat(request.headers().getAll(HttpHeaderNames.CONTENT_TYPE).get(0)).isEqualTo(XmlToJsonTransformationPolicy.APPLICATION_JSON);
+        assertThat(request.headers().names()).doesNotContain(HttpHeaderNames.TRANSFER_ENCODING);
+        assertThat(request.headers().names()).contains(HttpHeaderNames.CONTENT_LENGTH);
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = {
+            "wrong",
+            "application/soap+xml; charset=utf-8;",
+            "  ",
+            "application/soap+xml; charset=utf-8,",
+            "application/soap+xml; charset=utf-8",
+        }
+    )
+    @DisplayName("Should not fail when invalid charset is specified on response content")
+    void shouldNotFailWhenInvalidCharsetIsSpecifiedOnResponseContent(String contentType) throws Exception {
+        String input = loadResource("/com/graviteesource/policy/xml2json/input.xml");
+        String expected = loadResource("/com/graviteesource/policy/xml2json/expected.json");
+
+        // Prepare context
+        final HttpHeaders headers = HttpHeaders.create();
+        headers.set(HttpHeaderNames.CONTENT_TYPE, contentType);
+        when(configuration.getScope()).thenReturn(PolicyScope.RESPONSE);
+        when(response.headers()).thenReturn(headers);
+
+        final ReadWriteStream result = cut.onResponseContent(response, policyChain, executionContext);
+        assertThat(result).isNotNull();
+        result.bodyHandler(resultBody -> assertResultingJsonObjectsAreEquals(expected, resultBody));
+
+        result.write(Buffer.buffer(input));
+        result.end();
+
+        assertThat(response.headers().names()).contains(HttpHeaderNames.CONTENT_TYPE);
+        assertThat(response.headers().getAll(HttpHeaderNames.CONTENT_TYPE).get(0))
+            .isEqualTo(XmlToJsonTransformationPolicy.APPLICATION_JSON);
+        assertThat(response.headers().names()).doesNotContain(HttpHeaderNames.TRANSFER_ENCODING);
+        assertThat(response.headers().names()).contains(HttpHeaderNames.CONTENT_LENGTH);
+    }
+
+    private void assertResultingJsonObjectsAreEquals(String expected, Object resultBody) {
+        assertThat(resultBody).hasToString(expected);
+    }
+
+    private String loadResource(String resource) throws IOException {
+        InputStream is = this.getClass().getResourceAsStream(resource);
+        StringWriter sw = new StringWriter();
+        IOUtils.copy(is, sw, "UTF-8");
+        return sw.toString();
+    }
+}

--- a/src/test/java/com/graviteesource/policy/xml2json/XmlToJsonTransformationPolicyIntegrationTest.java
+++ b/src/test/java/com/graviteesource/policy/xml2json/XmlToJsonTransformationPolicyIntegrationTest.java
@@ -1,0 +1,163 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.graviteesource.policy.xml2json;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static io.vertx.core.http.HttpMethod.GET;
+import static io.vertx.core.http.HttpMethod.POST;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.matching.EqualToPattern;
+import com.graviteesource.policy.xml2json.configuration.XmlToJsonTransformationPolicyConfiguration;
+import io.gravitee.apim.gateway.tests.sdk.AbstractPolicyTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.vertx.rxjava3.core.buffer.Buffer;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@GatewayTest
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class XmlToJsonTransformationPolicyIntegrationTest
+    extends AbstractPolicyTest<XmlToJsonTransformationPolicy, XmlToJsonTransformationPolicyConfiguration> {
+
+    @Test
+    @DeployApi("/apis/v2/api-pre.json")
+    void should_post_xml_content_to_backend(HttpClient client) throws InterruptedException {
+        final String input = loadResource("/com/graviteesource/policy/xml2json/input.xml");
+        final String expected = loadResource("/com/graviteesource/policy/xml2json/expected.json");
+
+        wiremock.stubFor(post("/team").willReturn(ok("fefze")));
+
+        client
+            .rxRequest(POST, "/test")
+            .flatMap(request -> request.rxSend(Buffer.buffer(input)))
+            .flatMapPublisher(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                return response.toFlowable();
+            })
+            .test()
+            .await()
+            .assertComplete()
+            .assertNoErrors();
+
+        wiremock.verify(1, postRequestedFor(urlPathEqualTo("/team")).withRequestBody(new EqualToPattern(expected)));
+    }
+
+    @Test
+    @DeployApi("/apis/v2/api-pre.json")
+    void should_return_bad_request_when_posting_invalid_json_to_gateway(HttpClient client) throws InterruptedException {
+        final String input = loadResource("/com/graviteesource/policy/xml2json/invalid-input.xml");
+        client
+            .rxRequest(POST, "/test")
+            .flatMap(request -> request.rxSend(Buffer.buffer(input)))
+            .flatMapPublisher(response -> {
+                assertThat(response.statusCode()).isEqualTo(400);
+                return response.toFlowable();
+            })
+            .test()
+            .await()
+            .assertComplete()
+            .assertNoErrors();
+    }
+
+    @Test
+    @DeployApi("/apis/v2/api-post.json")
+    void should_get_json_content_from_backend(HttpClient client) throws InterruptedException {
+        final String expected = loadResource("/com/graviteesource/policy/xml2json/expected.json");
+        final String backendResponse = loadResource("/com/graviteesource/policy/xml2json/input.xml");
+        wiremock.stubFor(get("/team").willReturn(ok(backendResponse)));
+
+        client
+            .rxRequest(GET, "/test")
+            .flatMap(HttpClientRequest::rxSend)
+            .flatMapPublisher(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                return response.toFlowable();
+            })
+            .test()
+            .await()
+            .assertValue(buffer -> {
+                assertThat(buffer).hasToString(expected);
+                return true;
+            })
+            .assertComplete()
+            .assertNoErrors();
+
+        wiremock.verify(1, getRequestedFor(urlPathEqualTo("/team")));
+    }
+
+    @Test
+    @DeployApi("/apis/v2/api-post.json")
+    void should_return_internal_error_when_getting_invalid_xml_content_from_backend(HttpClient client) throws InterruptedException {
+        final String backendResponse = loadResource("/com/graviteesource/policy/xml2json/invalid-input.xml");
+        wiremock.stubFor(get("/team").willReturn(ok(backendResponse)));
+
+        client
+            .rxRequest(GET, "/test")
+            .flatMap(HttpClientRequest::rxSend)
+            .flatMapPublisher(response -> {
+                assertThat(response.statusCode()).isEqualTo(500);
+                return response.toFlowable();
+            })
+            .test()
+            .await()
+            .assertComplete()
+            .assertNoErrors();
+
+        wiremock.verify(1, getRequestedFor(urlPathEqualTo("/team")));
+    }
+
+    @Test
+    @DeployApi("/apis/v2/api-pre.json")
+    void should_return_internal_error_when_too_many_nested(HttpClient client) throws InterruptedException {
+        final String input = loadResource("/com/graviteesource/policy/xml2json/invalid-nested-object.xml");
+        client
+            .rxRequest(POST, "/test")
+            .flatMap(request -> request.rxSend(Buffer.buffer(input)))
+            .flatMapPublisher(response -> {
+                assertThat(response.statusCode()).isEqualTo(400);
+                return response.toFlowable();
+            })
+            .test()
+            .await()
+            .assertComplete()
+            .assertNoErrors();
+    }
+
+    protected String loadResource(String resource) {
+        try (InputStream is = this.getClass().getResourceAsStream(resource)) {
+            return new String(Objects.requireNonNull(is).readAllBytes(), StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/src/test/java/com/graviteesource/policy/xml2json/XmlToJsonTransformationPolicyTest.java
+++ b/src/test/java/com/graviteesource/policy/xml2json/XmlToJsonTransformationPolicyTest.java
@@ -1,37 +1,42 @@
 package com.graviteesource.policy.xml2json;
 
+import static com.graviteesource.policy.v3.xml2json.XmlToJsonTransformationPolicyV3.DEFAULT_MAX_DEPH;
+import static com.graviteesource.policy.v3.xml2json.XmlToJsonTransformationPolicyV3.POLICY_XML_JSON_MAXDEPTH;
+import static io.gravitee.common.http.HttpStatusCode.BAD_REQUEST_400;
+import static io.gravitee.common.http.HttpStatusCode.INTERNAL_SERVER_ERROR_500;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
-import com.graviteesource.policy.xml2json.configuration.PolicyScope;
 import com.graviteesource.policy.xml2json.configuration.XmlToJsonTransformationPolicyConfiguration;
-import io.gravitee.gateway.api.ExecutionContext;
-import io.gravitee.gateway.api.Request;
-import io.gravitee.gateway.api.Response;
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.http.HttpHeaders;
-import io.gravitee.gateway.api.stream.ReadWriteStream;
+import io.gravitee.gateway.reactive.api.ExecutionFailure;
+import io.gravitee.gateway.reactive.api.context.ExecutionContext;
+import io.gravitee.gateway.reactive.api.context.Request;
+import io.gravitee.gateway.reactive.api.context.Response;
+import io.gravitee.gateway.reactive.api.message.DefaultMessage;
+import io.gravitee.gateway.reactive.api.message.Message;
+import io.gravitee.gateway.reactive.core.context.interruption.InterruptionFailureException;
 import io.gravitee.node.api.configuration.Configuration;
-import io.gravitee.policy.api.PolicyChain;
-import io.gravitee.reporter.api.http.Metrics;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.MaybeTransformer;
+import io.reactivex.rxjava3.observers.TestObserver;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
-import java.time.Instant;
+import java.util.function.Function;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
@@ -47,221 +52,282 @@ class XmlToJsonTransformationPolicyTest {
     private XmlToJsonTransformationPolicyConfiguration configuration;
 
     @Mock
-    private PolicyChain policyChain;
+    private ExecutionContext ctx;
 
-    @Spy
+    @Mock
     private Request request;
 
-    @Spy
+    @Mock
     private Response response;
 
     @Mock
-    private ExecutionContext executionContext;
+    private Configuration mockConfiguration;
+
+    @Captor
+    private ArgumentCaptor<MaybeTransformer<Buffer, Buffer>> onBodyCaptor;
+
+    @Captor
+    private ArgumentCaptor<Function<Message, Maybe<Message>>> onMessageCaptor;
 
     @BeforeEach
     public void setUp() {
         cut = new XmlToJsonTransformationPolicy(configuration);
-        final Configuration config = mock(Configuration.class);
-        when(
-            config.getProperty(
-                XmlToJsonTransformationPolicy.POLICY_XML_JSON_MAXDEPTH,
-                Integer.class,
-                XmlToJsonTransformationPolicy.DEFAULT_MAX_DEPH
-            )
-        )
-            .thenReturn(XmlToJsonTransformationPolicy.DEFAULT_MAX_DEPH);
-        when(executionContext.getComponent(Configuration.class)).thenReturn(config);
+        lenient().when(ctx.request()).thenReturn(request);
+        lenient().when(ctx.response()).thenReturn(response);
+        lenient()
+            .when(mockConfiguration.getProperty(POLICY_XML_JSON_MAXDEPTH, Integer.class, DEFAULT_MAX_DEPH))
+            .thenReturn(DEFAULT_MAX_DEPH);
+        lenient().when(ctx.getComponent(Configuration.class)).thenReturn(mockConfiguration);
+
+        lenient().when(request.headers()).thenReturn(HttpHeaders.create());
+        lenient().when(response.headers()).thenReturn(HttpHeaders.create());
+        lenient()
+            .when(ctx.interruptBodyWith(any(ExecutionFailure.class)))
+            .thenAnswer(invocation -> Maybe.error(new InterruptionFailureException(invocation.getArgument(0))));
+        lenient()
+            .when(ctx.interruptMessageWith(any(ExecutionFailure.class)))
+            .thenAnswer(invocation -> Maybe.error(new InterruptionFailureException(invocation.getArgument(0))));
     }
 
     @Test
-    @DisplayName("Should transform and add header OnRequestContent")
-    public void shouldTransformAndAddHeadersOnRequestContent() throws Exception {
-        String input = loadResource("/com/graviteesource/policy/xml2json/input.xml");
-        String expected = loadResource("/com/graviteesource/policy/xml2json/expected.json");
-
-        // Prepare context
-        when(configuration.getScope()).thenReturn(PolicyScope.REQUEST);
-        when(request.headers()).thenReturn(HttpHeaders.create());
-
-        final ReadWriteStream result = cut.onRequestContent(request, policyChain, executionContext);
-        assertThat(result).isNotNull();
-        result.bodyHandler(resultBody -> {
-            assertResultingJsonObjectsAreEquals(expected, resultBody);
-        });
-
-        result.write(Buffer.buffer(input));
-        result.end();
-
-        assertThat(request.headers().names()).contains(HttpHeaderNames.CONTENT_TYPE);
-        assertThat(request.headers().getAll(HttpHeaderNames.CONTENT_TYPE).get(0)).isEqualTo(XmlToJsonTransformationPolicy.APPLICATION_JSON);
-        assertThat(request.headers().names()).doesNotContain(HttpHeaderNames.TRANSFER_ENCODING);
-        assertThat(request.headers().names()).contains(HttpHeaderNames.CONTENT_LENGTH);
-    }
-
-    @Test
-    @DisplayName("Should not transform when TransformationException thrown OnRequestContent")
-    public void shouldNotTransformAndAddHeadersOnRequestContent() throws Exception {
-        String input = loadResource("/com/graviteesource/policy/xml2json/invalid-input.xml");
-
-        // Prepare context
-        when(configuration.getScope()).thenReturn(PolicyScope.REQUEST);
-        when(request.headers()).thenReturn(HttpHeaders.create());
-        when(request.metrics()).thenReturn(Metrics.on(Instant.now().toEpochMilli()).build());
-
-        final ReadWriteStream result = cut.onRequestContent(request, policyChain, executionContext);
-        assertThat(result).isNotNull();
-
-        result.write(Buffer.buffer(input));
-        result.end();
-
-        assertThat(request.headers().names()).doesNotContain(HttpHeaderNames.CONTENT_TYPE);
-        assertThat(request.headers().names()).doesNotContain(HttpHeaderNames.TRANSFER_ENCODING);
-        assertThat(request.headers().names()).doesNotContain(HttpHeaderNames.CONTENT_LENGTH);
-        assertThat(request.metrics().getMessage()).contains("Unable to transform XML into JSON:");
-        verify(policyChain, times(1)).streamFailWith(any());
-    }
-
-    @Test
-    @DisplayName("Should reject too deep nested objects")
-    public void shouldRejectTooDeepNestedObject() throws Exception {
-        String input = loadResource("/com/graviteesource/policy/xml2json/invalid-nested-object.xml");
-
-        // Prepare context
-        when(configuration.getScope()).thenReturn(PolicyScope.REQUEST);
-        when(request.headers()).thenReturn(HttpHeaders.create());
-        when(request.metrics()).thenReturn(Metrics.on(Instant.now().toEpochMilli()).build());
-
-        final ReadWriteStream result = cut.onRequestContent(request, policyChain, executionContext);
-        assertThat(result).isNotNull();
-
-        result.write(Buffer.buffer(input));
-        result.end();
-
-        assertThat(request.headers().names()).doesNotContain(HttpHeaderNames.CONTENT_TYPE);
-        assertThat(request.headers().names()).doesNotContain(HttpHeaderNames.TRANSFER_ENCODING);
-        assertThat(request.headers().names()).doesNotContain(HttpHeaderNames.CONTENT_LENGTH);
-        assertThat(request.metrics().getMessage()).contains("Unable to transform XML into JSON:");
-        verify(policyChain, times(1)).streamFailWith(any());
-    }
-
-    @Test
-    @DisplayName("Should transform and add header OnResponseContent")
-    public void shouldTransformAndAddHeadersOnResponseContent() throws Exception {
-        String input = loadResource("/com/graviteesource/policy/xml2json/input.xml");
-        String expected = loadResource("/com/graviteesource/policy/xml2json/expected.json");
-
-        // Prepare context
-        when(configuration.getScope()).thenReturn(PolicyScope.RESPONSE);
-        when(response.headers()).thenReturn(HttpHeaders.create());
-
-        final ReadWriteStream result = cut.onResponseContent(response, policyChain, executionContext);
-        assertThat(result).isNotNull();
-        result.bodyHandler(resultBody -> {
-            assertResultingJsonObjectsAreEquals(expected, resultBody);
-        });
-
-        result.write(Buffer.buffer(input));
-        result.end();
-
-        assertThat(response.headers().names()).contains(HttpHeaderNames.CONTENT_TYPE);
-        assertThat(response.headers().getAll(HttpHeaderNames.CONTENT_TYPE).get(0))
-            .isEqualTo(XmlToJsonTransformationPolicy.APPLICATION_JSON);
-        assertThat(response.headers().names()).doesNotContain(HttpHeaderNames.TRANSFER_ENCODING);
-        assertThat(response.headers().names()).contains(HttpHeaderNames.CONTENT_LENGTH);
-    }
-
-    @Test
-    @DisplayName("Should not transform when TransformationException thrown OnResponseContent")
-    public void shouldNotTransformAndAddHeadersOnResponseContent() throws Exception {
-        String input = loadResource("/com/graviteesource/policy/xml2json/invalid-input.xml");
-
-        // Prepare context
-        when(configuration.getScope()).thenReturn(PolicyScope.RESPONSE);
-        when(response.headers()).thenReturn(HttpHeaders.create());
-
-        final ReadWriteStream result = cut.onResponseContent(response, policyChain, executionContext);
-        assertThat(result).isNotNull();
-
-        result.write(Buffer.buffer(input));
-        result.end();
-
-        assertThat(response.headers().names()).doesNotContain(HttpHeaderNames.CONTENT_TYPE);
-        assertThat(response.headers().names()).doesNotContain(HttpHeaderNames.TRANSFER_ENCODING);
-        assertThat(response.headers().names()).doesNotContain(HttpHeaderNames.CONTENT_LENGTH);
-        verify(policyChain, times(1)).streamFailWith(any());
-    }
-
-    @ParameterizedTest
-    @DisplayName("Should not fail when invalid charset is specified on request content")
-    @ValueSource(
-        strings = {
-            "wrong",
-            "application/soap+xml; charset=utf-8;",
-            "  ",
-            "application/soap+xml; charset=utf-8,",
-            "application/soap+xml; charset=utf-8",
-        }
-    )
-    public void shouldNotFailWhenInvalidCharsetIsSpecifiedOnRequestContent(String contentType) throws Exception {
-        String input = loadResource("/com/graviteesource/policy/xml2json/input.xml");
-        String expected = loadResource("/com/graviteesource/policy/xml2json/expected.json");
-
-        // Prepare context
+    @DisplayName("Should transform and add header OnRequest")
+    void shouldTransformAndAddHeadersOnRequest() throws Exception {
+        final String input = loadResource("/com/graviteesource/policy/xml2json/input.xml");
+        final String expected = loadResource("/com/graviteesource/policy/xml2json/expected.json");
         final HttpHeaders headers = HttpHeaders.create();
-        headers.set(HttpHeaderNames.CONTENT_TYPE, contentType);
-        when(configuration.getScope()).thenReturn(PolicyScope.REQUEST);
+
+        when(request.onBody(onBodyCaptor.capture())).thenReturn(Completable.complete());
         when(request.headers()).thenReturn(headers);
 
-        final ReadWriteStream result = cut.onRequestContent(request, policyChain, executionContext);
-        assertThat(result).isNotNull();
-        result.bodyHandler(resultBody -> assertResultingJsonObjectsAreEquals(expected, resultBody));
+        final TestObserver<Void> obs = cut.onRequest(ctx).test();
+        obs.assertNoValues();
 
-        result.write(Buffer.buffer(input));
-        result.end();
+        final TestObserver<Buffer> bodyObs = ((Maybe<Buffer>) onBodyCaptor.getValue().apply(Maybe.just(Buffer.buffer(input)))).test();
 
-        assertThat(request.headers().names()).contains(HttpHeaderNames.CONTENT_TYPE);
-        assertThat(request.headers().getAll(HttpHeaderNames.CONTENT_TYPE).get(0)).isEqualTo(XmlToJsonTransformationPolicy.APPLICATION_JSON);
-        assertThat(request.headers().names()).doesNotContain(HttpHeaderNames.TRANSFER_ENCODING);
-        assertThat(request.headers().names()).contains(HttpHeaderNames.CONTENT_LENGTH);
+        bodyObs.assertValue(buffer -> expected.equals(buffer.toString()));
+        verifyHeaders(request.headers());
     }
 
-    @ParameterizedTest
-    @ValueSource(
-        strings = {
-            "wrong",
-            "application/soap+xml; charset=utf-8;",
-            "  ",
-            "application/soap+xml; charset=utf-8,",
-            "application/soap+xml; charset=utf-8",
-        }
-    )
-    @DisplayName("Should not fail when invalid charset is specified on response content")
-    public void shouldNotFailWhenInvalidCharsetIsSpecifiedOnResponseContent(String contentType) throws Exception {
-        String input = loadResource("/com/graviteesource/policy/xml2json/input.xml");
-        String expected = loadResource("/com/graviteesource/policy/xml2json/expected.json");
+    @Test
+    @DisplayName("Should do nothing when no body OnRequest")
+    void shouldDoNothingWhenNoBodyOnRequest() {
+        when(request.onBody(onBodyCaptor.capture())).thenReturn(Completable.complete());
 
-        // Prepare context
+        final TestObserver<Void> obs = cut.onRequest(ctx).test();
+        obs.assertNoValues();
+
+        final TestObserver<Buffer> bodyObs = ((Maybe<Buffer>) onBodyCaptor.getValue().apply(Maybe.empty())).test();
+
+        bodyObs.assertNoValues();
+    }
+
+    @Test
+    @DisplayName("Should interrupt with failure when invalid json OnRequest")
+    void shouldInterruptWhenInvalidJsonOnRequest() throws IOException {
+        final String invalidInput = loadResource("/com/graviteesource/policy/xml2json/invalid-input.xml");
+        when(request.onBody(onBodyCaptor.capture())).thenReturn(Completable.complete());
+        when(request.headers()).thenReturn(HttpHeaders.create());
+
+        final TestObserver<Void> obs = cut.onRequest(ctx).test();
+        obs.assertNoValues();
+
+        ((Maybe<Buffer>) onBodyCaptor.getValue().apply(Maybe.just(Buffer.buffer(invalidInput)))).test()
+            .assertError(throwable -> {
+                assertThat(throwable).isInstanceOf(InterruptionFailureException.class);
+                InterruptionFailureException failureException = (InterruptionFailureException) throwable;
+                ExecutionFailure executionFailure = failureException.getExecutionFailure();
+                assertThat(executionFailure).isNotNull();
+                assertThat(executionFailure.key()).isEqualTo("XML_INVALID_PAYLOAD");
+                assertThat(executionFailure.statusCode()).isEqualTo(BAD_REQUEST_400);
+                assertThat(executionFailure.message()).isNotNull();
+
+                return true;
+            });
+    }
+
+    @Test
+    @DisplayName("Should interrupt with failure when max nested object reach OnRequest")
+    void shouldInterruptWhenMaxNestedObjectOnRequest() throws IOException {
+        final String invalidInput = loadResource("/com/graviteesource/policy/xml2json/invalid-nested-object.xml");
+        when(request.onBody(onBodyCaptor.capture())).thenReturn(Completable.complete());
+        when(request.headers()).thenReturn(HttpHeaders.create());
+
+        final TestObserver<Void> obs = cut.onRequest(ctx).test();
+        obs.assertNoValues();
+
+        ((Maybe<Buffer>) onBodyCaptor.getValue().apply(Maybe.just(Buffer.buffer(invalidInput)))).test()
+            .assertError(throwable -> {
+                assertThat(throwable).isInstanceOf(InterruptionFailureException.class);
+                InterruptionFailureException failureException = (InterruptionFailureException) throwable;
+                ExecutionFailure executionFailure = failureException.getExecutionFailure();
+                assertThat(executionFailure).isNotNull();
+                assertThat(executionFailure.key()).isEqualTo("XML_INVALID_PAYLOAD");
+                assertThat(executionFailure.statusCode()).isEqualTo(BAD_REQUEST_400);
+                assertThat(executionFailure.message()).isNotNull();
+
+                return true;
+            });
+    }
+
+    @Test
+    @DisplayName("Should transform and add header OnResponse")
+    void shouldTransformAndAddHeadersOnResponse() throws Exception {
+        final String input = loadResource("/com/graviteesource/policy/xml2json/input.xml");
+        final String expected = loadResource("/com/graviteesource/policy/xml2json/expected.json");
         final HttpHeaders headers = HttpHeaders.create();
-        headers.set(HttpHeaderNames.CONTENT_TYPE, contentType);
-        when(configuration.getScope()).thenReturn(PolicyScope.RESPONSE);
+
+        when(response.onBody(onBodyCaptor.capture())).thenReturn(Completable.complete());
         when(response.headers()).thenReturn(headers);
 
-        final ReadWriteStream result = cut.onResponseContent(response, policyChain, executionContext);
-        assertThat(result).isNotNull();
-        result.bodyHandler(resultBody -> assertResultingJsonObjectsAreEquals(expected, resultBody));
+        final TestObserver<Void> obs = cut.onResponse(ctx).test();
+        obs.assertNoValues();
 
-        result.write(Buffer.buffer(input));
-        result.end();
+        final TestObserver<Buffer> bodyObs = ((Maybe<Buffer>) onBodyCaptor.getValue().apply(Maybe.just(Buffer.buffer(input)))).test();
 
-        assertThat(response.headers().names()).contains(HttpHeaderNames.CONTENT_TYPE);
-        assertThat(response.headers().getAll(HttpHeaderNames.CONTENT_TYPE).get(0))
-            .isEqualTo(XmlToJsonTransformationPolicy.APPLICATION_JSON);
-        assertThat(response.headers().names()).doesNotContain(HttpHeaderNames.TRANSFER_ENCODING);
-        assertThat(response.headers().names()).contains(HttpHeaderNames.CONTENT_LENGTH);
+        bodyObs.assertValue(buffer -> expected.equals(buffer.toString()));
+        verifyHeaders(headers);
     }
 
-    private void assertResultingJsonObjectsAreEquals(String expected, Object resultBody) {
-        assertThat(resultBody.toString()).isEqualTo(expected);
+    @Test
+    @DisplayName("Should do nothing when no body OnResponse")
+    void shouldDoNothingWhenNoBodyOnResponse() {
+        when(response.onBody(onBodyCaptor.capture())).thenReturn(Completable.complete());
+
+        final TestObserver<Void> obs = cut.onResponse(ctx).test();
+        obs.assertNoValues();
+
+        final TestObserver<Buffer> bodyObs = ((Maybe<Buffer>) onBodyCaptor.getValue().apply(Maybe.empty())).test();
+
+        bodyObs.assertNoValues();
+    }
+
+    @Test
+    @DisplayName("Should interrupt with failure when invalid json OnResponse")
+    void shouldInterruptWhenInvalidJsonOnResponse() throws IOException {
+        final String invalidInput = loadResource("/com/graviteesource/policy/xml2json/invalid-input.xml");
+        when(response.onBody(onBodyCaptor.capture())).thenReturn(Completable.complete());
+        when(response.headers()).thenReturn(HttpHeaders.create());
+
+        final TestObserver<Void> obs = cut.onResponse(ctx).test();
+        obs.assertNoValues();
+
+        ((Maybe<Buffer>) onBodyCaptor.getValue().apply(Maybe.just(Buffer.buffer(invalidInput)))).test()
+            .assertError(throwable -> {
+                assertThat(throwable).isInstanceOf(InterruptionFailureException.class);
+                InterruptionFailureException failureException = (InterruptionFailureException) throwable;
+                ExecutionFailure executionFailure = failureException.getExecutionFailure();
+                assertThat(executionFailure).isNotNull();
+                assertThat(executionFailure.key()).isEqualTo("XML_INVALID_PAYLOAD");
+                assertThat(executionFailure.statusCode()).isEqualTo(INTERNAL_SERVER_ERROR_500);
+                assertThat(executionFailure.message()).isNotNull();
+
+                return true;
+            });
+    }
+
+    @Test
+    @DisplayName("Should transform OnMessageRequest")
+    void shouldTransformOnMessageRequest() throws Exception {
+        final String input = loadResource("/com/graviteesource/policy/xml2json/input.xml");
+        final String expected = loadResource("/com/graviteesource/policy/xml2json/expected.json");
+
+        when(request.onMessage(onMessageCaptor.capture())).thenReturn(Completable.complete());
+        when(request.headers()).thenReturn(HttpHeaders.create());
+
+        final TestObserver<Void> obs = cut.onMessageRequest(ctx).test();
+        obs.assertNoValues();
+
+        final TestObserver<Message> bodyObs = onMessageCaptor.getValue().apply(new DefaultMessage(input)).test();
+
+        bodyObs.assertValue(message -> {
+            assertThat(expected).isEqualTo(message.content().toString());
+            verifyHeaders(message.headers());
+            return true;
+        });
+    }
+
+    @Test
+    @DisplayName("Should raise an ExecutionFailure on OnMessageRequest with wrong xml content")
+    void shouldRaiseExceptionOnMessageRequestWithWrongContent() throws Exception {
+        final String invalidInput = loadResource("/com/graviteesource/policy/xml2json/invalid-input.xml");
+
+        when(request.onMessage(onMessageCaptor.capture())).thenReturn(Completable.complete());
+        when(request.headers()).thenReturn(HttpHeaders.create());
+
+        final TestObserver<Void> obs = cut.onMessageRequest(ctx).test();
+        obs.assertNoValues();
+
+        onMessageCaptor
+            .getValue()
+            .apply(new DefaultMessage(invalidInput))
+            .test()
+            .assertError(throwable -> {
+                assertThat(throwable).isInstanceOf(InterruptionFailureException.class);
+                InterruptionFailureException failureException = (InterruptionFailureException) throwable;
+                ExecutionFailure executionFailure = failureException.getExecutionFailure();
+                assertThat(executionFailure).isNotNull();
+                assertThat(executionFailure.key()).isEqualTo("XML_INVALID_MESSAGE_PAYLOAD");
+                assertThat(executionFailure.statusCode()).isEqualTo(BAD_REQUEST_400);
+                assertThat(executionFailure.message()).isNotNull();
+
+                return true;
+            });
+    }
+
+    @Test
+    @DisplayName("Should transform OnMessageResponse")
+    void shouldTransformOnMessageResponse() throws Exception {
+        final String input = loadResource("/com/graviteesource/policy/xml2json/input.xml");
+        final String expected = loadResource("/com/graviteesource/policy/xml2json/expected.json");
+
+        when(response.onMessage(onMessageCaptor.capture())).thenReturn(Completable.complete());
+        when(response.headers()).thenReturn(HttpHeaders.create());
+
+        final TestObserver<Void> obs = cut.onMessageResponse(ctx).test();
+        obs.assertNoValues();
+
+        final TestObserver<Message> bodyObs = onMessageCaptor.getValue().apply(new DefaultMessage(input)).test();
+
+        bodyObs.assertValue(message -> {
+            assertThat(expected).isEqualTo(message.content().toString());
+            verifyHeaders(message.headers());
+            return true;
+        });
+    }
+
+    @Test
+    @DisplayName("Should raise an ExecutionFailure on OnMessageResponse with wrong xml content")
+    void shouldRaiseExceptionOnMessageResponseWithWrongContent() throws Exception {
+        final String invalidInput = loadResource("/com/graviteesource/policy/xml2json/invalid-input.xml");
+
+        when(response.onMessage(onMessageCaptor.capture())).thenReturn(Completable.complete());
+        when(response.headers()).thenReturn(HttpHeaders.create());
+
+        final TestObserver<Void> obs = cut.onMessageResponse(ctx).test();
+        obs.assertNoValues();
+
+        onMessageCaptor
+            .getValue()
+            .apply(new DefaultMessage(invalidInput))
+            .test()
+            .assertError(throwable -> {
+                assertThat(throwable).isInstanceOf(InterruptionFailureException.class);
+                InterruptionFailureException failureException = (InterruptionFailureException) throwable;
+                ExecutionFailure executionFailure = failureException.getExecutionFailure();
+                assertThat(executionFailure).isNotNull();
+                assertThat(executionFailure.key()).isEqualTo("XML_INVALID_MESSAGE_PAYLOAD");
+                assertThat(executionFailure.statusCode()).isEqualTo(INTERNAL_SERVER_ERROR_500);
+                assertThat(executionFailure.message()).isNotNull();
+
+                return true;
+            });
+    }
+
+    private void verifyHeaders(HttpHeaders headers) {
+        assertThat(headers.names()).contains(HttpHeaderNames.CONTENT_TYPE);
+        assertThat(headers.getAll(HttpHeaderNames.CONTENT_TYPE).get(0)).isEqualTo(XmlToJsonTransformationPolicy.APPLICATION_JSON);
+        assertThat(headers.names()).doesNotContain(HttpHeaderNames.TRANSFER_ENCODING);
+        assertThat(headers.names()).contains(HttpHeaderNames.CONTENT_LENGTH);
     }
 
     private String loadResource(String resource) throws IOException {

--- a/src/test/java/com/graviteesource/policy/xml2json/XmlToJsonTransformationPolicyV3CompatibilityIntegrationTest.java
+++ b/src/test/java/com/graviteesource/policy/xml2json/XmlToJsonTransformationPolicyV3CompatibilityIntegrationTest.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.graviteesource.policy.xml2json;
+
+import static io.vertx.core.http.HttpMethod.POST;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayMode;
+import io.vertx.rxjava3.core.buffer.Buffer;
+import io.vertx.rxjava3.core.http.HttpClient;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@GatewayTest(mode = GatewayMode.COMPATIBILITY)
+public class XmlToJsonTransformationPolicyV3CompatibilityIntegrationTest extends XmlToJsonTransformationPolicyIntegrationTest {
+
+    @Override
+    @Test
+    @DisplayName("Should return Bad Request when posting invalid json to gateway")
+    @DeployApi("/apis/v2/api-pre.json")
+    void should_return_bad_request_when_posting_invalid_json_to_gateway(HttpClient client) throws InterruptedException {
+        final String input = loadResource("/com/graviteesource/policy/xml2json/invalid-input.xml");
+
+        client
+            .rxRequest(POST, "/test")
+            .flatMap(request -> request.rxSend(Buffer.buffer(input)))
+            .flatMapPublisher(response -> {
+                assertThat(response.statusCode()).isEqualTo(500);
+                return response.toFlowable();
+            })
+            .test()
+            .await()
+            .assertComplete()
+            .assertNoErrors();
+    }
+
+    @Override
+    @Test
+    @DeployApi("/apis/v2/api-pre.json")
+    void should_return_internal_error_when_too_many_nested(HttpClient client) throws InterruptedException {
+        final String input = loadResource("/com/graviteesource/policy/xml2json/invalid-nested-object.xml");
+        client
+            .rxRequest(POST, "/test")
+            .flatMap(request -> request.rxSend(Buffer.buffer(input)))
+            .flatMapPublisher(response -> {
+                assertThat(response.statusCode()).isEqualTo(500);
+                return response.toFlowable();
+            })
+            .test()
+            .await()
+            .assertComplete()
+            .assertNoErrors();
+    }
+}

--- a/src/test/java/com/graviteesource/policy/xml2json/XmlToJsonTransformationPolicyV4IntegrationTest.java
+++ b/src/test/java/com/graviteesource/policy/xml2json/XmlToJsonTransformationPolicyV4IntegrationTest.java
@@ -1,0 +1,288 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.graviteesource.policy.xml2json;
+
+import static io.vertx.core.http.HttpMethod.GET;
+import static io.vertx.core.http.HttpMethod.POST;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.graviteesource.entrypoint.http.get.HttpGetEntrypointConnectorFactory;
+import com.graviteesource.entrypoint.http.post.HttpPostEntrypointConnectorFactory;
+import com.graviteesource.policy.xml2json.configuration.XmlToJsonTransformationPolicyConfiguration;
+import com.graviteesource.reactor.message.MessageApiReactorFactory;
+import io.gravitee.apim.gateway.tests.sdk.AbstractPolicyTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.fakes.MessageStorage;
+import io.gravitee.apim.gateway.tests.sdk.connector.fakes.PersistentMockEndpointConnectorFactory;
+import io.gravitee.apim.gateway.tests.sdk.reactor.ReactorBuilder;
+import io.gravitee.apim.plugin.reactor.ReactorPlugin;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.gateway.api.http.HttpHeaderNames;
+import io.gravitee.gateway.reactive.reactor.v4.reactor.ReactorFactory;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.endpoint.mock.MockEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.rxjava3.core.buffer.Buffer;
+import io.vertx.rxjava3.core.http.HttpClient;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class XmlToJsonTransformationPolicyV4IntegrationTest {
+
+    @Nested
+    @GatewayTest
+    class HttpProxy extends XmlToJsonTransformationPolicyIntegrationTest {
+
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+        }
+
+        @Override
+        public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+            endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+        }
+
+        @Override
+        @Test
+        @DeployApi("/apis/v4/api-request.json")
+        void should_post_xml_content_to_backend(HttpClient client) throws InterruptedException {
+            super.should_post_xml_content_to_backend(client);
+        }
+
+        @Override
+        @Test
+        @DeployApi("/apis/v4/api-request.json")
+        void should_return_bad_request_when_posting_invalid_json_to_gateway(HttpClient client) throws InterruptedException {
+            super.should_return_bad_request_when_posting_invalid_json_to_gateway(client);
+        }
+
+        @Override
+        @Test
+        @DeployApi("/apis/v4/api-response.json")
+        void should_get_json_content_from_backend(HttpClient client) throws InterruptedException {
+            super.should_get_json_content_from_backend(client);
+        }
+
+        @Override
+        @Test
+        @DeployApi("/apis/v4/api-response.json")
+        void should_return_internal_error_when_getting_invalid_xml_content_from_backend(HttpClient client) throws InterruptedException {
+            super.should_return_internal_error_when_getting_invalid_xml_content_from_backend(client);
+        }
+
+        @Override
+        @Test
+        @DeployApi("/apis/v4/api-request.json")
+        void should_return_internal_error_when_too_many_nested(HttpClient client) throws InterruptedException {
+            super.should_return_internal_error_when_too_many_nested(client);
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class Subscribe extends AbstractPolicyTest<XmlToJsonTransformationPolicy, XmlToJsonTransformationPolicyConfiguration> {
+
+        @Override
+        public void configureReactors(Set<ReactorPlugin<? extends ReactorFactory<?>>> reactors) {
+            reactors.add(ReactorBuilder.build(MessageApiReactorFactory.class));
+        }
+
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            entrypoints.putIfAbsent("http-get", EntrypointBuilder.build("http-get", HttpGetEntrypointConnectorFactory.class));
+        }
+
+        @Override
+        public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+            endpoints.putIfAbsent("mock", EndpointBuilder.build("mock", MockEndpointConnectorFactory.class));
+        }
+
+        @Test
+        @DeployApi("/apis/v4/api-subscribe.json")
+        void should_transform_on_response_message(HttpClient client) {
+            var expected = loadResource("/com/graviteesource/policy/xml2json/expected.json");
+
+            client
+                .rxRequest(GET, "/test")
+                .flatMap(request -> request.putHeader(HttpHeaderNames.ACCEPT, MediaType.APPLICATION_JSON).rxSend())
+                .flatMap(response -> {
+                    assertThat(response.statusCode()).isEqualTo(200);
+                    return response.body();
+                })
+                .map(Buffer::toString)
+                .test()
+                .awaitDone(5, TimeUnit.SECONDS)
+                .assertValue(body -> {
+                    final JsonObject content = new JsonObject(body.toString());
+                    final JsonArray items = content.getJsonArray("items");
+                    assertThat(items).hasSize(2);
+                    items.forEach(item -> {
+                        JsonObject message = (JsonObject) item;
+                        assertThat(message.getString("content")).isEqualTo(expected);
+                        final JsonObject headers = message.getJsonObject("headers");
+                        assertThat(headers.getJsonArray("Content-Type")).hasSize(1).contains("application/json;charset=UTF-8");
+                        assertThat(headers.getJsonArray("Content-Length")).hasSize(1).contains("65");
+                    });
+                    return true;
+                });
+        }
+
+        @Test
+        @DeployApi("/apis/v4/api-subscribe-invalid-xml.json")
+        void should_respond_with_500_when_invalid_xml_from_backend(HttpClient client) {
+            client
+                .rxRequest(GET, "/test")
+                .flatMap(request -> request.putHeader(HttpHeaderNames.ACCEPT, MediaType.APPLICATION_JSON).rxSend())
+                .flatMap(response -> {
+                    assertThat(response.statusCode()).isEqualTo(200);
+                    return response.body();
+                })
+                .map(Buffer::toString)
+                .test()
+                .awaitDone(5, TimeUnit.SECONDS)
+                .assertValue(body -> {
+                    final JsonObject content = new JsonObject(body);
+                    final JsonArray items = content.getJsonArray("items");
+                    assertThat(items).isEmpty();
+                    final JsonObject error = content.getJsonObject("error");
+                    final JsonObject errorContent = new JsonObject(error.getString("content"));
+                    assertThat(errorContent.getString("message")).isEqualTo("Unable to transform invalid XML message to JSON");
+                    assertThat(errorContent.getString("http_status_code")).isEqualTo("500");
+                    final JsonObject headers = error.getJsonObject("headers");
+                    assertThat(headers.getJsonArray("Content-Type")).hasSize(1).contains("application/json");
+                    assertThat(headers.getJsonArray("Content-Length")).hasSize(1).contains("84");
+                    final JsonObject metadata = error.getJsonObject("metadata");
+                    assertThat(metadata.getString("reason")).isEqualTo("Internal Server Error");
+                    assertThat(metadata.getString("key")).isEqualTo("XML_INVALID_MESSAGE_PAYLOAD");
+                    assertThat(metadata.getInteger("statusCode")).isEqualTo(500);
+
+                    return true;
+                });
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class Publish extends AbstractPolicyTest<XmlToJsonTransformationPolicy, XmlToJsonTransformationPolicyConfiguration> {
+
+        private MessageStorage messageStorage;
+
+        @Override
+        public void configureReactors(Set<ReactorPlugin<? extends ReactorFactory<?>>> reactors) {
+            reactors.add(ReactorBuilder.build(MessageApiReactorFactory.class));
+        }
+
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            entrypoints.putIfAbsent("http-post", EntrypointBuilder.build("http-post", HttpPostEntrypointConnectorFactory.class));
+        }
+
+        @Override
+        public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+            endpoints.putIfAbsent("mock", EndpointBuilder.build("mock", PersistentMockEndpointConnectorFactory.class));
+        }
+
+        @BeforeEach
+        void setUp() {
+            messageStorage = getBean(MessageStorage.class);
+        }
+
+        @AfterEach
+        void tearDown() {
+            messageStorage.reset();
+        }
+
+        @Test
+        @DeployApi("/apis/v4/api-publish.json")
+        void should_transform_on_request_message(HttpClient client) {
+            var expected = loadResource("/com/graviteesource/policy/xml2json/expected.json");
+            var messageContent = loadResource("/com/graviteesource/policy/xml2json/input.xml");
+
+            client
+                .rxRequest(POST, "/test")
+                .flatMap(request -> request.rxSend(messageContent))
+                .flatMap(response -> {
+                    assertThat(response.statusCode()).isEqualTo(202);
+                    return response.body();
+                })
+                .test()
+                .awaitDone(5, TimeUnit.SECONDS);
+
+            messageStorage
+                .subject()
+                .test()
+                .assertValue(message -> {
+                    assertThat(message.content()).hasToString(expected);
+                    return true;
+                })
+                .dispose();
+        }
+
+        @Test
+        @DeployApi("/apis/v4/api-publish.json")
+        void should_respond_with_500_when_posting_invalid_xml(HttpClient client) {
+            var param = loadResource("/com/graviteesource/policy/xml2json/invalid-input.xml");
+
+            client
+                .rxRequest(POST, "/test")
+                .flatMap(request -> request.rxSend(param))
+                .flatMap(response -> {
+                    assertThat(response.statusCode()).isEqualTo(500);
+                    return response.body();
+                })
+                .test()
+                .awaitDone(5, TimeUnit.SECONDS)
+                .assertValue(buffer -> {
+                    assertThat(buffer).hasToString("Internal Server Error");
+                    return true;
+                });
+
+            messageStorage.subject().test().assertNoValues().dispose();
+        }
+    }
+
+    protected String loadResource(String resource) {
+        try (InputStream is = this.getClass().getResourceAsStream(resource)) {
+            return new String(Objects.requireNonNull(is).readAllBytes(), StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/src/test/java/com/graviteesource/policy/xml2json/utils/CharsetHelperTest.java
+++ b/src/test/java/com/graviteesource/policy/xml2json/utils/CharsetHelperTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.gravitee.common.http.MediaType;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**

--- a/src/test/resources/apis/v2/api-post.json
+++ b/src/test/resources/apis/v2/api-post.json
@@ -1,0 +1,44 @@
+{
+  "id": "my-api-post",
+  "name": "my-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/team",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "flow-1",
+      "methods": [
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [
+      ],
+      "post": [
+        {
+          "name": "XML to JSON",
+          "description": "",
+          "enabled": true,
+          "policy": "xml-json",
+          "configuration": {
+            "scope": "RESPONSE"
+          }
+        }
+      ]
+    }
+  ],
+  "resources": []
+}

--- a/src/test/resources/apis/v2/api-pre.json
+++ b/src/test/resources/apis/v2/api-pre.json
@@ -1,0 +1,44 @@
+{
+  "id": "my-api-get",
+  "name": "my-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/team",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "flow-1",
+      "methods": [
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [
+        {
+          "name": "XML to JSON",
+          "description": "",
+          "enabled": true,
+          "policy": "xml-json",
+          "configuration": {
+            "scope": "REQUEST"
+          }
+        }
+      ],
+      "post": [
+      ]
+    }
+  ],
+  "resources": []
+}

--- a/src/test/resources/apis/v4/api-publish.json
+++ b/src/test/resources/apis/v4/api-publish.json
@@ -1,0 +1,71 @@
+{
+  "id": "api-publish",
+  "name": "api-publish",
+  "apiVersion": "1.0",
+  "definitionVersion": "4.0.0",
+  "type": "message",
+  "analytics": {},
+  "description": "api-request",
+  "properties" : [],
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-post",
+          "configuration": {
+            "requestHeadersToMessage": true
+          }
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default",
+      "type": "mock",
+      "endpoints": [
+        {
+          "name": "default-endpoint",
+          "type": "mock",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "messageInterval": 1,
+            "messageContent": "<root></root>",
+            "messageCount": 2
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "flow-1",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/",
+          "pathOperator": "STARTS_WITH"
+        }
+      ],
+      "publish": [
+        {
+          "name": "Xml to Json",
+          "description": "",
+          "enabled": true,
+          "policy": "xml-json",
+          "configuration": {
+          }
+        }
+      ],
+      "subscribe": []
+    }
+  ]
+}

--- a/src/test/resources/apis/v4/api-request.json
+++ b/src/test/resources/apis/v4/api-request.json
@@ -1,0 +1,66 @@
+{
+  "id": "api-request",
+  "name": "api-request",
+  "apiVersion": "1.0",
+  "definitionVersion": "4.0.0",
+  "type": "proxy",
+  "analytics": {},
+  "description": "api-request",
+  "properties" : [],
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-proxy"
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "configuration": {
+            "target": "http://localhost:8080/team"
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "flow-1",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/",
+          "pathOperator": "STARTS_WITH"
+        }
+      ],
+      "request": [
+        {
+          "name": "Xml to Json",
+          "description": "",
+          "enabled": true,
+          "policy": "xml-json",
+          "configuration": {
+          }
+        }
+      ],
+      "response": [],
+      "subscribe": [],
+      "publish": []
+    }
+  ]
+}

--- a/src/test/resources/apis/v4/api-response.json
+++ b/src/test/resources/apis/v4/api-response.json
@@ -1,0 +1,68 @@
+{
+  "id": "api-request",
+  "name": "api-request",
+  "apiVersion": "1.0",
+  "definitionVersion": "4.0.0",
+  "type": "proxy",
+  "analytics": {},
+  "description": "api-request",
+  "properties" : [],
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-proxy"
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "configuration": {
+            "target": "http://localhost:8080/team"
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "flow-1",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/",
+          "pathOperator": "STARTS_WITH"
+        }
+      ],
+      "request": [
+
+      ],
+      "response": [
+        {
+          "name": "Xml to Json",
+          "description": "",
+          "enabled": true,
+          "policy": "xml-json",
+          "configuration": {
+          }
+        }
+      ],
+      "subscribe": [],
+      "publish": []
+    }
+  ]
+}

--- a/src/test/resources/apis/v4/api-subscribe-invalid-xml.json
+++ b/src/test/resources/apis/v4/api-subscribe-invalid-xml.json
@@ -1,0 +1,80 @@
+{
+  "id": "api-request",
+  "name": "api-request",
+  "apiVersion": "1.0",
+  "definitionVersion": "4.0.0",
+  "type": "message",
+  "analytics": {},
+  "description": "api-request",
+  "properties" : [],
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-get",
+          "configuration": {
+            "messagesLimitCount":  2,
+            "messagesLimitDurationMs": 500,
+            "headersInPayload":  true,
+            "metadataInPayload": true
+          }
+        },
+        {
+          "type": "http-post",
+          "configuration": {
+            "requestHeadersToMessage": true
+          }
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default",
+      "type": "mock",
+      "endpoints": [
+        {
+          "name": "default-endpoint",
+          "type": "mock",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "messageInterval": 1,
+            "messageContent": "<<<<invalid input>>>>",
+            "messageCount": 2
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "flow-1",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/",
+          "pathOperator": "STARTS_WITH"
+        }
+      ],
+      "subscribe": [
+        {
+          "name": "Xml to Json",
+          "description": "",
+          "enabled": true,
+          "policy": "xml-json",
+          "configuration": {
+          }
+        }
+      ],
+      "publish": []
+    }
+  ]
+}

--- a/src/test/resources/apis/v4/api-subscribe.json
+++ b/src/test/resources/apis/v4/api-subscribe.json
@@ -1,0 +1,80 @@
+{
+  "id": "api-request",
+  "name": "api-request",
+  "apiVersion": "1.0",
+  "definitionVersion": "4.0.0",
+  "type": "message",
+  "analytics": {},
+  "description": "api-request",
+  "properties" : [],
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-get",
+          "configuration": {
+            "messagesLimitCount":  2,
+            "messagesLimitDurationMs": 500,
+            "headersInPayload":  true,
+            "metadataInPayload": true
+          }
+        },
+        {
+          "type": "http-post",
+          "configuration": {
+            "requestHeadersToMessage": true
+          }
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default",
+      "type": "mock",
+      "endpoints": [
+        {
+          "name": "default-endpoint",
+          "type": "mock",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "messageInterval": 1,
+            "messageContent": "<root>\n    <_id>57762dc6ab7d620000000001</_id>\n    <name>name</name><__v>0</__v>\n</root>",
+            "messageCount": 2
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "flow-1",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/",
+          "pathOperator": "STARTS_WITH"
+        }
+      ],
+      "subscribe": [
+        {
+          "name": "Xml to Json",
+          "description": "",
+          "enabled": true,
+          "policy": "xml-json",
+          "configuration": {
+          }
+        }
+      ],
+      "publish": []
+    }
+  ]
+}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright (c) 2015-2016, The Gravitee team (http://www.gravitee.io)
+  ~
+  ~  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~  http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  -->
+
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{5} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="io.gravitee" level="DEBUG" additivity="false">
+        <appender-ref ref="STDOUT" />
+    </logger>
+
+    <!-- Strictly speaking, the level attribute is not necessary since -->
+    <!-- the level of the root level is set to DEBUG by default.       -->
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
BREAKING CHANGE: this version is using the latest dependencies introduced by gravitee 4.0

**Issue**

https://gravitee.atlassian.net/browse/APIM-1624
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/com/graviteesource/policy/gravitee-policy-xml-json/2.0.0/gravitee-policy-xml-json-2.0.0.zip)
  <!-- Version placeholder end -->
