### PR TITLE
chore(deps): clean dependencies version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,7 @@
         <gravitee-entrypoint-http-get.version>1.0.0</gravitee-entrypoint-http-get.version>
         <gravitee-reactor-message.version>1.0.1</gravitee-reactor-message.version>
 
-        <swagger-parser.version>2.0.14</swagger-parser.version>
-        <slf4j.version>1.7.26</slf4j.version>
+        <swagger-parser.version>2.1.13</swagger-parser.version>
         <json-unit-assertj.version>3.0.0</json-unit-assertj.version>
 
         <json-schema-generator-maven-plugin.version>1.1.0</json-schema-generator-maven-plugin.version>
@@ -112,7 +111,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -249,6 +247,7 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>${maven-assembly-plugin.version}</version>
                 <configuration>


### PR DESCRIPTION
**Description**

Remove explicit version of slf4j to use the one from bom
Use the same version as APIM for `swagger-parser`

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-xml-json/2.0.0/gravitee-policy-xml-json-2.0.0.zip)
  <!-- Version placeholder end -->
