### PR TITLE
ci: test new orb to add a community build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@4.1.0
+    gravitee: gravitee-io/gravitee@dev:4.2.0
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/pom.xml
+++ b/pom.xml
@@ -187,18 +187,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.graviteesource.entrypoint</groupId>
-            <artifactId>gravitee-entrypoint-http-get</artifactId>
-            <version>${gravitee-entrypoint-http-get.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.graviteesource.entrypoint</groupId>
-            <artifactId>gravitee-entrypoint-http-post</artifactId>
-            <version>${gravitee-entrypoint-http-post.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.gravitee.apim.plugin.endpoint</groupId>
             <artifactId>gravitee-apim-plugin-endpoint-http-proxy</artifactId>
             <version>${gravitee-apim.version}</version>
@@ -208,12 +196,6 @@
             <groupId>io.gravitee.apim.plugin.endpoint</groupId>
             <artifactId>gravitee-apim-plugin-endpoint-mock</artifactId>
             <version>${gravitee-apim.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.graviteesource.reactor</groupId>
-            <artifactId>gravitee-reactor-message</artifactId>
-            <version>${gravitee-reactor-message.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -266,6 +248,73 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>test-compile</phase>
+                        <configuration>
+                            <testExcludes>
+                                <exclude>com/graviteesource/**/*IntegrationTest.java</exclude>
+                            </testExcludes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>enterprise-integration-tests</id>
+            <activation>
+                <property>
+                    <name>enterprise-integration-tests</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.graviteesource.entrypoint</groupId>
+                    <artifactId>gravitee-entrypoint-http-get</artifactId>
+                    <version>${gravitee-entrypoint-http-get.version}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.entrypoint</groupId>
+                    <artifactId>gravitee-entrypoint-http-post</artifactId>
+                    <version>${gravitee-entrypoint-http-post.version}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.reactor</groupId>
+                    <artifactId>gravitee-reactor-message</artifactId>
+                    <version>${gravitee-reactor-message.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-testCompile</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>integration-enterprise-testCompile</id>
+                                <phase>test-compile</phase>
+                                <goals>
+                                    <goal>testCompile</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/src/test/java/com/graviteesource/policy/XmlToJsonTransformationPolicyV4MessageIntegrationTest.java
+++ b/src/test/java/com/graviteesource/policy/XmlToJsonTransformationPolicyV4MessageIntegrationTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.policy.xml2json;
+package com.graviteesource.policy;
 
 import static io.vertx.core.http.HttpMethod.GET;
 import static io.vertx.core.http.HttpMethod.POST;
@@ -36,10 +36,9 @@ import io.gravitee.common.http.MediaType;
 import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.reactive.reactor.v4.reactor.ReactorFactory;
 import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
-import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
 import io.gravitee.plugin.endpoint.mock.MockEndpointConnectorFactory;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
-import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.gravitee.policy.xml2json.XmlToJsonTransformationPolicy;
 import io.gravitee.policy.xml2json.configuration.XmlToJsonTransformationPolicyConfiguration;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -62,57 +61,7 @@ import org.junit.jupiter.api.Test;
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class XmlToJsonTransformationPolicyV4IntegrationTest {
-
-    @Nested
-    @GatewayTest
-    class HttpProxy extends XmlToJsonTransformationPolicyV4EmulationEngineIntegrationTest {
-
-        @Override
-        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
-            entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
-        }
-
-        @Override
-        public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
-            endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
-        }
-
-        @Override
-        @Test
-        @DeployApi("/apis/v4/api-request.json")
-        void should_post_xml_content_to_backend(HttpClient client) throws InterruptedException {
-            super.should_post_xml_content_to_backend(client);
-        }
-
-        @Override
-        @Test
-        @DeployApi("/apis/v4/api-request.json")
-        void should_return_bad_request_when_posting_invalid_json_to_gateway(HttpClient client) throws InterruptedException {
-            super.should_return_bad_request_when_posting_invalid_json_to_gateway(client);
-        }
-
-        @Override
-        @Test
-        @DeployApi("/apis/v4/api-response.json")
-        void should_get_json_content_from_backend(HttpClient client) throws InterruptedException {
-            super.should_get_json_content_from_backend(client);
-        }
-
-        @Override
-        @Test
-        @DeployApi("/apis/v4/api-response.json")
-        void should_return_internal_error_when_getting_invalid_xml_content_from_backend(HttpClient client) throws InterruptedException {
-            super.should_return_internal_error_when_getting_invalid_xml_content_from_backend(client);
-        }
-
-        @Override
-        @Test
-        @DeployApi("/apis/v4/api-request.json")
-        void should_return_internal_error_when_too_many_nested(HttpClient client) throws InterruptedException {
-            super.should_return_internal_error_when_too_many_nested(client);
-        }
-    }
+public class XmlToJsonTransformationPolicyV4MessageIntegrationTest {
 
     @Nested
     @GatewayTest

--- a/src/test/java/io/gravitee/policy/xml2json/XmlToJsonTransformationPolicyV4ProxyIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/xml2json/XmlToJsonTransformationPolicyV4ProxyIntegrationTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.xml2json;
+
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.vertx.rxjava3.core.http.HttpClient;
+import java.util.Map;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@GatewayTest
+public class XmlToJsonTransformationPolicyV4ProxyIntegrationTest extends XmlToJsonTransformationPolicyV4EmulationEngineIntegrationTest {
+
+    @Override
+    public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+    }
+
+    @Override
+    public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+        endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+    }
+
+    @Override
+    @Test
+    @DeployApi("/apis/v4/api-request.json")
+    void should_post_xml_content_to_backend(HttpClient client) throws InterruptedException {
+        super.should_post_xml_content_to_backend(client);
+    }
+
+    @Override
+    @Test
+    @DeployApi("/apis/v4/api-request.json")
+    void should_return_bad_request_when_posting_invalid_json_to_gateway(HttpClient client) throws InterruptedException {
+        super.should_return_bad_request_when_posting_invalid_json_to_gateway(client);
+    }
+
+    @Override
+    @Test
+    @DeployApi("/apis/v4/api-response.json")
+    void should_get_json_content_from_backend(HttpClient client) throws InterruptedException {
+        super.should_get_json_content_from_backend(client);
+    }
+
+    @Override
+    @Test
+    @DeployApi("/apis/v4/api-response.json")
+    void should_return_internal_error_when_getting_invalid_xml_content_from_backend(HttpClient client) throws InterruptedException {
+        super.should_return_internal_error_when_getting_invalid_xml_content_from_backend(client);
+    }
+
+    @Override
+    @Test
+    @DeployApi("/apis/v4/api-request.json")
+    void should_return_internal_error_when_too_many_nested(HttpClient client) throws InterruptedException {
+        super.should_return_internal_error_when_too_many_nested(client);
+    }
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-3447

**Description**

- Use latest Gravitee-Orb version to add a check-community-build in the CI process.
- Split integration tests to separate community and enterprise tests.

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.1`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-xml-json/2.0.1/gravitee-policy-xml-json-2.0.1.zip)
  <!-- Version placeholder end -->
